### PR TITLE
Locking down dangerous functions in the global space

### DIFF
--- a/src/eval/index.php
+++ b/src/eval/index.php
@@ -74,7 +74,7 @@
 		$sandbox->allow_functions = true;
 		$sandbox->allow_closures = true;
 		$sandbox->allow_constants = true;
-		$sandbox->allow_aliases = true;
+		$sandbox->allow_aliases = false;
 		$sandbox->allow_interfaces = true;
 		$sandbox->allow_casting = true;
 		$sandbox->allow_classes = true;

--- a/src/eval/index.php
+++ b/src/eval/index.php
@@ -62,7 +62,8 @@
 							"imagecreatefromwbmp", "imagecreatefromxbm", "imagecreatefromxpm", "ftp_put", "ftp_nb_put",
 							"exif_read_data", "read_exif_data", "exif_thumbnail", "exif_imagetype", "hash_file", "hash_hmac_file",
 							"hash_update_file", "md5_file", "sha1_file", "highlight_file", "show_source", "php_strip_whitespace",
-							"get_meta_tags", "set_time_limit", "call_user_func", "call_user_func_array"
+							"get_meta_tags", "set_time_limit", "call_user_func", "call_user_func_array", "php_execute_raw",
+							'Composer\Autoload\includeFile'
 					);
 
 		$whiteList = array('print_r', 'preg_match', 'preg_replace', 'preg_match_all');

--- a/vendor/composer/autoload_real.php
+++ b/vendor/composer/autoload_real.php
@@ -42,14 +42,14 @@ class ComposerAutoloaderInitc5eb6c61dea33c587b462d2698a7e677
 
         $includeFiles = require __DIR__ . '/autoload_files.php';
         foreach ($includeFiles as $file) {
-            composerRequirec5eb6c61dea33c587b462d2698a7e677($file);
+            self::composerRequirec5eb6c61dea33c587b462d2698a7e677($file);
         }
 
         return $loader;
     }
-}
 
-function composerRequirec5eb6c61dea33c587b462d2698a7e677($file)
-{
-    require $file;
+    private static function composerRequirec5eb6c61dea33c587b462d2698a7e677($file)
+    {
+        require $file;
+    }
 }


### PR DESCRIPTION
This is meant to fix #32.

As you may have noticed, I disabled aliasing. It is just way too dangerous at the moment and it seems like [fieryprophet/php-sandbox](https://github.com/fieryprophet/php-sandbox) will possibly have to be modified to hook/wrap it. For example, simply blacklisting `'Composer\Autoload\includeFile'` will not block:
```PHP
use Composer\Autoload as NotAutoload;
NotAutoload\includeFile('/etc/shells');
```

Additionally, PHP 5.6+ supports `use function` aliases (though the PHP parser used by the included [fieryprophet/php-sandbox](https://github.com/fieryprophet/php-sandbox) does not recognize this yet) that will also throw a big wrench into things if not handled by the sandbox. With function aliasing things like the following become possible:
```PHP
use function system as notsystem;
notsystem("id");
```

Lastly, it seems like Composer is intent on adding dangerous functions into the environment.
I modified the `composerRequire<hash>` stuff just to use a private static function that seems to be "safe" from sandboxed code. I say "safe" as it appears that the differences between the environment that the parser sees and the one that running code sees are enough that the parser fails on included classes and even ones that would work at runtime via the use of `class_alias`, but I'm not sure if this will hold up against changes to the parser/sandbox that possibly add features supporting this. It might be necessary to do the includes in a manual way that is less generic, but I can't say for certain. This change will likely have to be re-applied continuously for every time Composer generates a new set of files. While it would be simpler to just replace that one call with a `require`, I'm not sure if future Composer-generated files will add more logic in there, so I thought I'd just add in a more generic way of handling this.
